### PR TITLE
fix: only execute logic when amount > 0

### DIFF
--- a/contracts/dao/Treasury.sol
+++ b/contracts/dao/Treasury.sol
@@ -259,19 +259,21 @@ contract PrismaTreasury is PrismaOwnable, SystemStart {
         @param claimant Address that is claiming the tokens
         @param receiver Address to transfer tokens to
         @param amount Desired amount of tokens to transfer. This value always assumes max boost.
-        @return uint256 Actual amount of tokens transferred, plus the sum left behind due to
+        @return claimed Actual amount of tokens transferred, plus the sum left behind due to
                         insufficient boost. May be less than `amount` if tokens were locked.
      */
-    function transferAllocatedTokens(address claimant, address receiver, uint256 amount) external returns (uint256) {
-        allocated[msg.sender] -= amount;
-        amount += pendingRewardFor[claimant];
-        pendingRewardFor[claimant] = 0;
-        uint256 claimed;
+    function transferAllocatedTokens(
+        address claimant,
+        address receiver,
+        uint256 amount
+    ) external returns (uint256 claimed) {
         if (amount > 0) {
+            allocated[msg.sender] -= amount;
+            amount += pendingRewardFor[claimant];
+            pendingRewardFor[claimant] = 0;
             claimed = _transferAllocated(claimant, receiver, address(0), amount);
             pendingRewardFor[claimant] += amount - claimed;
         }
-
         return claimed;
     }
 


### PR DESCRIPTION
Fixes a bug in `transferAllocatedTokens` that would allow anyone to claim `pendingRewardFor` tokens from other accounts.

`allocated[msg.sender] -= amount` was intended to prevent unauthorized callers, however this could be circumvented with an `amount` of `0`. `pendingRewardFor` is then added to the amount, and so anyone could call to transfer this pending amount to anyone else.

The pending reward is typically dust (less than `1e18`) however with boost delegation it also includes the received delegate fees, which could result in significant amounts.

We have fixed by moving `if (amount > 0)` to the first line within the function, so that it is impossible to circumvent the `allocated` check with an initial amount of zero.  We choose this instead of a `require` statement to prevent breaking caller contracts that might not check for `amount > 0` prior to calling.