### PR TITLE
Guardian

### DIFF
--- a/contracts/core/TroveManager.sol
+++ b/contracts/core/TroveManager.sol
@@ -79,7 +79,7 @@ contract TroveManager is PrismaBase, PrismaOwnable, SystemStart {
 
     uint256 public systemDeploymentTime;
     bool public sunsetting;
-    bool private paused;
+    bool public paused;
 
     uint256 public baseRate;
 
@@ -279,7 +279,8 @@ contract TroveManager is PrismaBase, PrismaOwnable, SystemStart {
      *         - New collateral deposits are not possible
      * @param _paused If true the protocol is paused
      */
-    function setPaused(bool _paused) external onlyOwner {
+    function setPaused(bool _paused) external {
+        require((_paused && msg.sender == guardian()) || msg.sender == owner(), "Unauthorized");
         paused = _paused;
     }
 

--- a/contracts/dependencies/PrismaOwnable.sol
+++ b/contracts/dependencies/PrismaOwnable.sol
@@ -24,4 +24,8 @@ contract PrismaOwnable {
     function owner() public view returns (address) {
         return PRISMA_CORE.owner();
     }
+
+    function guardian() public view returns (address) {
+        return PRISMA_CORE.guardian();
+    }
 }

--- a/contracts/interfaces/IPrismaCore.sol
+++ b/contracts/interfaces/IPrismaCore.sol
@@ -5,6 +5,8 @@ pragma solidity 0.8.19;
 interface IPrismaCore {
     function owner() external view returns (address);
 
+    function guardian() external view returns (address);
+
     function feeReceiver() external view returns (address);
 
     function priceFeed() external view returns (address);
@@ -14,4 +16,6 @@ interface IPrismaCore {
     function startTime() external view returns (uint256);
 
     function acceptTransferOwnership() external;
+
+    function setGuardian(address guardian) external;
 }


### PR DESCRIPTION
Adds a secondary ownership role within Prisma, the `guardian`

The guardian is intended to be a multisig comprised of known, prominent members of the defi community.  It has the authority to:

* pause protocol operations (in case of a critical exploit)
* block the execution of DAO votes (in case of a malicious vote that achieves quorum)

If the guardian acts maliciously, the DAO can vote to change or remove them - and the guardian cannot block this vote.