### PR TITLE
fix: while loop in getAccountWeightAt

### DIFF
--- a/contracts/dao/TokenLocker.sol
+++ b/contracts/dao/TokenLocker.sol
@@ -179,7 +179,7 @@ contract TokenLocker is SystemStart {
         }
 
         uint256 bitfield = accountData.updateWeeks[accountWeek / 256] >> (accountWeek % 256);
-        while (accountWeek < systemWeek) {
+        while (accountWeek < week) {
             accountWeek++;
             weight -= locked;
             if (accountWeek % 256 == 0) {


### PR DESCRIPTION
Only iterate until the desired historical week within `getAccountWeightAt`. Previously we were iterating until the current week, so querying historic weeks would be incorrect.

As reported by Nomoi.