### PR TITLE
removing redundant variable newDeposit

### DIFF
--- a/contracts/core/StabilityPool.sol
+++ b/contracts/core/StabilityPool.sol
@@ -795,9 +795,8 @@ contract StabilityPool is PrismaOwnable, SystemStart {
             // we update only if the snapshot has changed
             if (debtLoss > 0 || hasGains || amount > 0) {
                 // Update deposit
-                uint256 newDeposit = compoundedDebtDeposit;
-                accountDeposits[account] = AccountDeposit({ amount: uint128(newDeposit), timestamp: depositTimestamp });
-                _updateSnapshots(account, newDeposit);
+                accountDeposits[account] = AccountDeposit({ amount: uint128(compoundedDebtDeposit), timestamp: depositTimestamp });
+                _updateSnapshots(account, compoundedDebtDeposit);
             }
         }
         uint256 pending = storedPendingReward[account];


### PR DESCRIPTION
In the `_claimReward` function, a new variable `newDeposit` is declared with the value of `compoundedDeposit`. 
Note that both `newDeposit` and `compoundedDeposit` are memory variables, and the `newDeposit` is always the same as the `compoundedDeposit`. 
Thus, there is no need to declare a new variable `newDeposit`.

Recommend removing the redundant variable `newDeposit` to save gas.